### PR TITLE
fix plotVisium() according to new SPE class structure

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,53 @@
+.get_pal <- function(pal, val) {
+    # (if missing) default to 'viridis' for continuous
+    # and 'libd_layer_colors' for discrete scales
+    if (is.null(pal)) 
+        pal <- ifelse(is.numeric(val), "viridis", "libd_layer_colors")
+    # if length(palette) > 1, use palette as provided 
+    # (either multiple colors for discrete labels, 
+    # or length 2 for continuous gradient)
+    if (length(pal) == 1) {
+        pal <- switch(pal,
+            "libd_layer_colors" = c(
+                "#F0027F", "#377EB8", "#4DAF4A", "#984EA3", 
+                "#FFD700", "#FF7F00", "#1A1A1A", "#666666"),
+            "Okabe-Ito" = c(
+                "#000000", "#E69F00", "#56B4E9", "#009E73", 
+                "#F0E442", "#0072B2", "#D55E00", "#CC79A7"),
+            # use 'scale_fill_viridis_c' instead of hex codes or color names
+            "viridis" = pal,
+            # if providing a single color name (e.g. 'navy' or 'red'), 
+            # combine with 'gray95' for continuous color scale
+            c("gray95", pal)
+        )
+    }
+    return(pal)
+}
+
+#' @importFrom SpatialExperiment imgData
+.sub_imgData <- function(spe, sample_ids, image_ids) {
+    .get_img_idx <- SpatialExperiment:::.get_img_idx
+    if (is.null(image_ids)) {
+        # default to first available image for each sample
+        idx <- .get_img_idx(spe, TRUE, NULL)
+    } else {
+        if (length(image_ids) == 1) {
+            idx <- .get_img_idx(spe, TRUE, image_ids)
+        } else {
+          stopifnot(length(image_ids) == length(sample_ids))
+          idx <- mapply(s = sample_ids, i = image_ids,
+            function(s, i) .get_img_idx(spe, s, i))
+        }
+    }
+    imgData(spe)[idx, ]
+         
+}
+
+.flip_xy <- function(df, x, y) {
+    x_tmp <- df[ix, y]
+    y_tmp <- df[ix, x]
+    y_tmp <- (-1 * y_tmp) + min(y_tmp) + max(y_tmp)
+    df[ix, x] <- x_tmp
+    df[ix, y] <- y_tmp
+    return(df)
+}

--- a/man/plotVisium.Rd
+++ b/man/plotVisium.Rd
@@ -8,12 +8,14 @@ plotVisium(
   spe,
   spots = TRUE,
   fill = NULL,
-  highlight = "in_tissue",
+  highlight = NULL,
   facets = "sample_id",
   image = TRUE,
+  assay = "logcounts",
+  trans = "identity",
   x_coord = "x",
   y_coord = "y",
-  flip_xy_Visium = FALSE,
+  flip_xy = FALSE,
   sample_ids = NULL,
   image_ids = NULL,
   palette = NULL
@@ -41,13 +43,21 @@ disable.}
 \item{image}{(logical) Whether to show histology image as background. Default
 = TRUE.}
 
+\item{assay}{(character) Name of assay data to use 
+when \code{fill} is in \code{rownames(spe)}.
+Should be one of \code{assayNames(spe)}.}
+
+\item{trans}{Transformation to apply for continuous scales.
+Ignored unless \code{fill} is numeric, e.g. feature expression.
+(See \code{\link{ggplot2}{continuous_scale}} for valid options)}
+
 \item{x_coord}{(character) Column in 'spatialData' containing x-coordinates.
 Default = 'x'.}
 
 \item{y_coord}{(character) Column in 'spatialData' containing y-coordinates.
 Default = 'y'.}
 
-\item{flip_xy_Visium}{(logical) Whether to flip x and y coordinates and
+\item{flip_xy}{(logical) Whether to flip x and y coordinates and
 reverse y scale to match orientation of histology images. This is sometimes
 required for Visium data, depending on the orientation of the raw data.}
 
@@ -81,11 +91,19 @@ transcriptomics data from the 10x Genomics Visium platform, with several
 options available to adjust the plot type and style.
 }
 \examples{
-# library(ggspavis)
-# library(STdata)
-# spe <- load_data("Visium_mouseCoronal")
-# plotVisium(spe)
+library(ggspavis)
+library(STexampleData)
+spe <- load_data("Visium_mouseCoronal")
 
+# color by x coordinate, highlight in-tissue spots
+plotVisium(spe, fill = "x", highlight = "in_tissue")
+
+# subset in-tissue spots
+sub <- spe[, inTissue(spe)]
+
+# color by feature counts, don't include image
+rownames(sub) <- make.names(rowData(sub)$gene_name)
+plotVisium(sub, fill = "Gad2", assay = "counts", image = FALSE)
 }
 \author{
 Helena L. Crowell and Lukas M. Weber


### PR DESCRIPTION
this PR:
- updated `plotVisium()` to work with new `SpatialExperiment` class structure
- added arguments `assay` and `trans` for more flexibility
- put some code into `utils.R` for readability, reusability and unit testing (e.g. `.get_pal` could be used across multiple functions to define a suitable color palette)

to do / think about:
- should add more flexibility, e.g. to facet by multiple features for a single sample, or both (multiple samples and features using `facet_grid`)
- could add an argument to control the color of `highlights`
- wondering whether `palette` is making things too complicated and might be unstable. E.g., users could easily write the below and be infinitely more flexible. 
```
plotVisium(..., fill = "sample_id") + 
  scale_fill_brewer(palette = "Set1")
  
plotVisium(..., fill = "feature") + 
  scale_fill_viridis_c(name = "expression", trans = "sqrt")
  
...
```